### PR TITLE
retry logic for auth adapter credentials refresh

### DIFF
--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -62,8 +62,6 @@ defmodule ExAws.Config.AuthCache do
   end
 
   def refresh_awscli_config(profile, expiration, ets) do
-    Process.send_after(self(), {:refresh_awscli_config, profile, expiration}, expiration)
-
     auth = ExAws.Config.awscli_auth_credentials(profile)
 
     auth =
@@ -72,12 +70,33 @@ defmodule ExAws.Config.AuthCache do
           auth
 
         adapter ->
-          adapter.adapt_auth_config(auth, profile, expiration)
+          attempt_credentials_refresh(adapter, auth, profile, expiration)
       end
 
+    Process.send_after(self(), {:refresh_awscli_config, profile, expiration}, expiration)
     :ets.insert(ets, {{:awscli, profile}, auth})
 
     auth
+  end
+
+  defp attempt_credentials_refresh(adapter, auth, profile, expiration, retries \\ 6) do
+    case adapter.adapt_auth_config(auth, profile, expiration) do
+      {:error, error} ->
+        if retries == 1 do
+          Process.send_after(self(), {:refresh_awscli_config, profile, expiration}, expiration)
+
+          raise "Could't get credentials from auth adapter after 6 retries, last error was #{inspect error}"
+        else
+          Process.sleep(:rand.uniform(5_000))
+          attempt_credentials_refresh(adapter, auth, profile, expiration, retries - 1)
+        end
+
+      # Always store a map on AuthCache
+      auth when is_map(auth) ->
+        auth
+
+      _unexpected -> %{}
+    end
   end
 
   defp refresh_auth_if_required([], config) do

--- a/test/ex_aws/auth/auth_cache_test.exs
+++ b/test/ex_aws/auth/auth_cache_test.exs
@@ -71,4 +71,62 @@ defmodule ExAws.AuthCacheTest do
 
     assert_receive @response, 1000
   end
+
+  test "using adapter retries when there is an error" do
+    # The flaky adapter simulates failures on the adapter side
+    # for a few a tries and then returns a successful response.
+
+    defmodule FlakyAdapter do
+      @moduledoc false
+
+      @behaviour ExAws.Config.AuthCache.AuthConfigAdapter
+
+      @config %{
+        access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        region: "us-east-1"
+      }
+
+      def init do
+        :ets.new(__MODULE__, [:named_table, :set, :public, read_concurrency: true])
+        :ets.insert(__MODULE__, {:count, 0})
+      end
+
+      @impl true
+      def adapt_auth_config(_config, _profile, _expiration) do
+        [count: count] = :ets.lookup(__MODULE__, :count)
+
+        if count < 3 do
+          :ets.insert(__MODULE__, {:count, count + 1})
+          {:error, %{status_code: 400, body: "Throttling", reason: "Throttling"}}
+        else
+          @config
+        end
+      end
+    end
+
+    FlakyAdapter.init()
+    Application.put_env(:ex_aws, :awscli_auth_adapter, FlakyAdapter)
+
+    op = %ExAws.Operation.S3{
+      body: "",
+      bucket: "",
+      headers: %{},
+      http_method: :get,
+      params: [],
+      parser: & &1,
+      path: "/",
+      resource: "",
+      service: :s3,
+      stream_builder: nil
+    }
+
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      @response
+    end)
+
+    Process.sleep(100)
+    assert ExAws.request(op, @config) == @response
+  end
 end


### PR DESCRIPTION
**Description**

This PR aims to add retry logic for Throttling errors through the STS auth adapter.
The algorithm takes the 30 seconds window from the `AuthCache` GenServer cast call [here](https://github.com/ex-aws/ex_aws/blob/main/lib/ex_aws/config/auth_cache.ex#L33) into six windows.

On each window, the process will wait a random amount of time from 0 to 5 seconds to sleep and retry later.

The objective here is to try to distribute colliding clients in a more normalized way across the 30 second window.

Finally, if the 6 retries are not enough, we just raise an error instead of polluting the cache with a tuple (since all the logic around it assumes a map is stored)